### PR TITLE
Api fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,7 +46,7 @@ app/components
 server/config/environments/local.py
 server/media
 server/public/static
-server/static/survey/components/
+
 .vagrant
 geosurvey_env
 logs

--- a/fabfile.py
+++ b/fabfile.py
@@ -229,7 +229,7 @@ def restart():
 @task
 def restore(file=None):
     if file is not None:
-        run(" pg_restore --verbose --clean --no-acl --no-owner -d %s /vagrant/%s" % (project, file))
+        run(" pg_restore --verbose --clean --create --no-acl --no-owner -d %s /vagrant/%s" % (project, file))
 
 @task
 def vagrant(username='vagrant'):

--- a/server/apps/survey/api.py
+++ b/server/apps/survey/api.py
@@ -152,9 +152,7 @@ class ReportRespondantResource(SurveyModelResource):
 
 class CompleteRespondantResource(ReportRespondantResource):
     """
-    This name is not good. It serves surveys,  if you only want complete surveys, user filter complete=true
 
-    This is used in the dashbaord to load surveys
     """
     project_name = fields.CharField(attribute='project_name', readonly=True)
     organization_name = fields.CharField(attribute='organization_name', readonly=True)
@@ -184,7 +182,7 @@ class CompleteRespondantResource(ReportRespondantResource):
 
     class Meta:
 
-        queryset = Respondant.objects.all().annotate(responses_count=Count("responses")).filter(responses_count__gte=1).order_by("-ts")
+        queryset = Respondant.objects.all().annotate(responses_count=Count("responses")).filter(responses_count__gte=1, complete__exact=True).order_by("-ts")
         #queryset = Respondant.objects.filter(responses_count__gte=1).order_by('-ts')
 
         filtering = {
@@ -220,10 +218,18 @@ class OLDDashRespondantResource(ReportRespondantResource):
 class DashRespondantResource(ReportRespondantResource):
     """
     /api/v1/dashrespondant/
-    This endpoint is used by the searcxh box feature on the dashboard  
+    This endpoint is used by the search box feature on the dashboard,
+    and by the respondent tables.
 
-
+    To search by ecosystem features use 'ef':
     
+
+    To search:
+    /api/v1/dashrespondant/search?q=rocky
+
+    To seach complete surveys only
+    /api/v1/dashrespondant/search?q=rocky&complete=true
+
 
     """
     
@@ -283,7 +289,6 @@ class DashRespondantResource(ReportRespondantResource):
             ]
 
     def get_search(self, request, **kwargs):
-        import pdb; pdb.set_trace()
         self.method_check(request, allowed=['get'])
         self.is_authenticated(request)
         self.throttle_check(request)

--- a/server/apps/survey/api.py
+++ b/server/apps/survey/api.py
@@ -211,15 +211,20 @@ class IncompleteRespondantResource(ReportRespondantResource):
         authentication = Authentication()
 
 
-class OLDDashRespondantResource(ReportRespondantResource):
-    user = fields.ToOneField('apps.account.api.UserResource', 'user', null=True, blank=True, full=True, readonly=True)
-
 
 class DashRespondantResource(ReportRespondantResource):
     """
     /api/v1/dashrespondant/
+
+    /api/v1/dashrespondant/search   <-- Search Mode
+
+
     This endpoint is used by the search box feature on the dashboard,
     and by the respondent tables.
+
+    If using search mode endpoint, pagiantion is handled with the page parameter not
+    the offset parameter.  
+
 
     To search by ecosystem features use 'ef':
     
@@ -297,12 +302,17 @@ class DashRespondantResource(ReportRespondantResource):
         limit = int(request.GET.get('limit', 20))
         query = request.GET.get('q', '')
         page = int(request.GET.get('page', 1))
+        complete = request.GET.get('complete',True)
         start_date = request.GET.get('start_date', None)
         end_date = request.GET.get('end_date', None)
         review_status = request.GET.get('review_status', None)
         entered_by = request.GET.get('entered_by', None)
         island = request.GET.get('island', None)
+        
+        
         sqs = SearchQuerySet().models(Respondant).load_all()
+        if complete == u'true':
+            sqs = sqs.filter(complete=True)
 
         if query != '':
             sqs = sqs.auto_query(query)

--- a/server/apps/survey/search_indexes.py
+++ b/server/apps/survey/search_indexes.py
@@ -7,14 +7,15 @@ class RespondentIndex(indexes.SearchIndex, indexes.Indexable):
     #username = indexes.CharField()
     text = indexes.CharField(document=True, use_template=True)
     ordering_date = indexes.DateTimeField(model_attr='ts')
-    
+    complete = indexes.BooleanField(model_attr='complete')
+
 
     def get_model(self):
         return Respondant
 
     def index_queryset(self, using=None):
         """Used when the entire index for model is updated."""
-        qs = self.get_model().objects.filter(status='complete').select_related('survey')
+        qs = self.get_model().objects.all().select_related('survey')
         return qs
 
     def prepare_username(self, obj):

--- a/server/apps/survey/templates/survey/dash.html
+++ b/server/apps/survey/templates/survey/dash.html
@@ -132,7 +132,7 @@
     <script src="{{ STATIC_URL }}survey/assets/js/filters.js"></script>
     <script src="{{ STATIC_URL }}survey/assets/js/directives/directives.js"></script>
     <script src="{{ STATIC_URL }}survey/assets/js/directives/full-height.js"></script>
-    <script src="{{ STATIC_URL }}survey/assets/js/directives/RespondentsTable.js"></script>
+    <script src="{{ STATIC_URL }}survey/components/p97-respondent-table/directives.js"></script>
     <script src="{{ STATIC_URL }}survey/assets/js/directives/dash-map-ost.js"></script>
     <script src="{{ STATIC_URL }}survey/lib/js/angular-strap.js"></script>
     <script src="{{ STATIC_URL }}survey/lib/js/angular-strap.tpl.js"></script>

--- a/server/static/survey/assets/js/controllers/RespondantList.js
+++ b/server/static/survey/assets/js/controllers/RespondantList.js
@@ -11,13 +11,18 @@ angular.module('askApp')
     $scope.user = app.user || {};
     $scope.searchTerm = $location.search().q;
     
-    $scope.resource
+    // Setup respondent table params and options
+    var complete = ($scope.user.is_staff !== true);
+    $scope.respondentTable={
+        resource:'/api/v1/dashrespondant/search',
+        params:{complete:complete},
+        options:{limit:10}
+    };
+
     
     $scope.survey = {};
-    $scope.survey.slug = $routeParams.survey_slug;    
+    $scope.survey.slug = $routeParams.survey_slug;
 
-    $scope.respondents_per_page = 10;
-    $scope.busy = true;
     $scope.viewPath = app.server + '/static/survey/';
     $scope.activePage = 'responses';
 
@@ -25,30 +30,6 @@ angular.module('askApp')
         data.questions.reverse();
         $scope.survey = data;
     });
-
-    if ($scope.searchTerm){
-        $scope.resource = '/api/v1/dashrespondant/search';
-    } else {
-        $scope.resource = '/api/v1/dashrespondant';
-    }
-
-    if (!$scope.user.is_staff){
-        url = url+'&complete=true';
-    }
-
-    // $http.get(url).success(function(data) {
-    //     $scope.respondents = data.objects;
-    //     $scope.meta = data.meta;
-    //     $scope.responsesShown = $scope.respondents.length;
-    //     $scope.busy = false;
-    // });
-
-
-
-    $scope.OLDshowRespondent = function (respondent) {
-        var path = ['/RespondantDetail', $routeParams.surveySlug, respondent.uuid].join('/');
-        $location.path(path);
-    };
 
 
     $scope.getAnswer = function(questionSlug, respondent) {

--- a/server/static/survey/assets/js/controllers/RespondantList.js
+++ b/server/static/survey/assets/js/controllers/RespondantList.js
@@ -11,6 +11,7 @@ angular.module('askApp')
     $scope.user = app.user || {};
     $scope.searchTerm = $location.search().q;
     
+    $scope.resource
     
     $scope.survey = {};
     $scope.survey.slug = $routeParams.survey_slug;    
@@ -26,17 +27,21 @@ angular.module('askApp')
     });
 
     if ($scope.searchTerm){
-        var url = '/api/v1/dashrespondant/search/?format=json&limit='+$scope.respondents_per_page+'&q=' + $scope.searchTerm;
+        $scope.resource = '/api/v1/dashrespondant/search';
     } else {
-        var url = '/api/v1/dashrespondant/?format=json&limit='+$scope.respondents_per_page;
+        $scope.resource = '/api/v1/dashrespondant';
     }
 
-    $http.get(url).success(function(data) {
-        $scope.respondents = data.objects;
-        $scope.meta = data.meta;
-        $scope.responsesShown = $scope.respondents.length;
-        $scope.busy = false;
-    });
+    if (!$scope.user.is_staff){
+        url = url+'&complete=true';
+    }
+
+    // $http.get(url).success(function(data) {
+    //     $scope.respondents = data.objects;
+    //     $scope.meta = data.meta;
+    //     $scope.responsesShown = $scope.respondents.length;
+    //     $scope.busy = false;
+    // });
 
 
 

--- a/server/static/survey/assets/js/controllers/RespondantList.js
+++ b/server/static/survey/assets/js/controllers/RespondantList.js
@@ -10,7 +10,7 @@ angular.module('askApp')
     $scope.page_title = "Search Results"
     $scope.user = app.user || {};
     $scope.searchTerm = $location.search().q;
-    $scope.resource = '/api/v1/dashrespondant/';
+    
     
     $scope.survey = {};
     $scope.survey.slug = $routeParams.survey_slug;    

--- a/server/static/survey/assets/js/controllers/ost/dash-explore.js
+++ b/server/static/survey/assets/js/controllers/ost/dash-explore.js
@@ -7,11 +7,10 @@ angular.module('askApp').controller('DashExploreCtrl', function($scope, $http, $
     
     
     // Setup respondent table params and options
-    debugger
     var complete = ($scope.user.is_staff !== true)
     $scope.respondentTable={
         resource:'/api/v1/dashrespondant/',
-        params:{complete:complete },
+        params:{complete:complete},
         options:{limit:10}
     };
 

--- a/server/static/survey/assets/js/controllers/ost/dash-explore.js
+++ b/server/static/survey/assets/js/controllers/ost/dash-explore.js
@@ -5,7 +5,6 @@ angular.module('askApp').controller('DashExploreCtrl', function($scope, $http, $
     $scope.activePage = 'explore';
     $scope.user = app.user || {};
     
-    $scope.resource = '/api/v1/completerespondant/';
     
     $scope.respondents_per_page = 10;
     

--- a/server/static/survey/assets/js/controllers/ost/dash-explore.js
+++ b/server/static/survey/assets/js/controllers/ost/dash-explore.js
@@ -6,7 +6,15 @@ angular.module('askApp').controller('DashExploreCtrl', function($scope, $http, $
     $scope.user = app.user || {};
     
     
-    $scope.respondents_per_page = 10;
+    // Setup respondent table params and options
+    debugger
+    var complete = ($scope.user.is_staff !== true)
+    $scope.respondentTable={
+        resource:'/api/v1/dashrespondant/',
+        params:{complete:complete },
+        options:{limit:10}
+    };
+
     
     //
     // Charts

--- a/server/static/survey/assets/js/controllers/ost/dash-overview.js
+++ b/server/static/survey/assets/js/controllers/ost/dash-overview.js
@@ -7,9 +7,19 @@ angular.module('askApp').controller('DashOverviewCtrl', function($scope, $http, 
         $scope.activePage = 'overview';
         $scope.user = app.user || {};
 
+
         $scope.filtersJson = '';
         $scope.filters = { ecosystemFeatures: [] };
         
+        // Setup respondent table params and options
+        var complete = ($scope.user.is_staff !== true)
+        $scope.respondentTable={
+            resource:'/api/v1/dashrespondant/',
+            params:{complete:complete },
+            options:{limit:3}
+        };
+
+
         // Get or load survey
         $scope.survey = {};
         $scope.survey.slug = $routeParams.survey_slug;
@@ -38,7 +48,7 @@ angular.module('askApp').controller('DashOverviewCtrl', function($scope, $http, 
             });
 
             // Update respondent table
-            $scope.goToPage(1, $scope.filters.ecosystemFeatures);
+            //$scope.goToPage(1, $scope.filters.ecosystemFeatures);
 
         });
     }

--- a/server/static/survey/assets/js/controllers/ost/dash-overview.js
+++ b/server/static/survey/assets/js/controllers/ost/dash-overview.js
@@ -39,15 +39,17 @@ angular.module('askApp').controller('DashOverviewCtrl', function($scope, $http, 
         $scope.updateMap();
 
         $scope.$watch('filters.ecosystemFeatures', function(newVal, oldVal) {
-            $scope.filtersJson = [];
             
+            // Update $scope.respondentTable so it reloads with new filters in place
+            $scope.respondentTable.params.ef = $scope.filters.ecosystemFeatures;
+
+
+            // Not sure where this is used
+            $scope.filtersJson = [];
             _.each($scope.filters.ecosystemFeatures, function (label) {
                 var slug = ecosystemLabelToSlug(label);
                 //$scope.filtersJson.push({'ecosystem-features': slug});
             });
-
-            // Update respondent table
-            //$scope.goToPage(1, $scope.filters.ecosystemFeatures);
 
         });
     }

--- a/server/static/survey/assets/js/controllers/ost/dash-overview.js
+++ b/server/static/survey/assets/js/controllers/ost/dash-overview.js
@@ -16,9 +16,8 @@ angular.module('askApp').controller('DashOverviewCtrl', function($scope, $http, 
         $scope.respondentTable={
             resource:'/api/v1/dashrespondant/',
             params:{complete:complete },
-            options:{limit:3}
+            options:{limit:10}
         };
-
 
         // Get or load survey
         $scope.survey = {};

--- a/server/static/survey/assets/js/directives/RespondentsTable.js
+++ b/server/static/survey/assets/js/directives/RespondentsTable.js
@@ -20,7 +20,6 @@ angular.module('askApp')
         restrict: 'EA',
         templateUrl : app.viewPath +'views/ost/dash-respondents-table.html',
         scope: {respondents: '=',
-                resource:'=',
                 meta:'=',
                 limit:'='
             },
@@ -30,6 +29,8 @@ angular.module('askApp')
             scope.meta = null;
             scope.http = http;
             scope.surveySlug = surveyFactory.survey.slug;
+
+            scope.resource = '/api/v1/dashrespondant/';
 
             scope.location = location;
 
@@ -65,7 +66,7 @@ angular.module('askApp')
                 });
             };
             // Only load first page if not results from a text search
-            if (scope.resource === '/api/v1/completerespondant/'){
+            if (scope.searchTerm.length>0){
                 scope.goToPage(1);
             }
 

--- a/server/static/survey/assets/js/directives/RespondentsTable.js
+++ b/server/static/survey/assets/js/directives/RespondentsTable.js
@@ -21,6 +21,7 @@ angular.module('askApp')
         templateUrl : app.viewPath +'views/ost/dash-respondents-table.html',
         scope: {respondents: '=',
                 meta:'=',
+                resource:'=',
                 limit:'='
             },
 
@@ -29,21 +30,17 @@ angular.module('askApp')
             scope.meta = null;
             scope.http = http;
             scope.surveySlug = surveyFactory.survey.slug;
+            scope.location = location;
 
             scope.resource = '/api/v1/dashrespondant/';
 
-            scope.location = location;
-
-            scope.showRespondent = function(respondent){
-                scope.location.path('/RespondantDetail/'+respondent.survey_slug+'/'+respondent.uuid );
-            };
+            // Get the search term from the URL
+            scope.searchTerm = scope.location.search().q;
 
             // Paginated respondent table
             scope.goToPage = function (page) {
-
-
-                scope.searchTerm = scope.location.search().q;
-
+                // Need to find a way to include ecosuystem features here
+                
                 var meta = scope.meta || {}
                     , offset = scope.limit * (page - 1);
 
@@ -66,7 +63,8 @@ angular.module('askApp')
                 });
             };
             // Only load first page if not results from a text search
-            if (scope.searchTerm.length>0){
+            
+            if (typeof(scope.searchTerm) !== 'undefined'){
                 scope.goToPage(1);
             }
 
@@ -78,6 +76,10 @@ angular.module('askApp')
                 } else {
                     scope.orderBy = field;
                 }
+            };
+
+            scope.showRespondent = function(respondent){
+                scope.location.path('/RespondantDetail/'+respondent.survey_slug+'/'+respondent.uuid );
             };
 
         }

--- a/server/static/survey/components/p97-respondent-table/directives.js
+++ b/server/static/survey/components/p97-respondent-table/directives.js
@@ -61,8 +61,8 @@ angular.module('askApp')
                     
                     // make sure the to parts is not grater than the total count.
                     var results_to = data.meta.offset + data.meta.limit;
-                    results_to = ( results_to > data.meta.total_count ) ? data.meta.total_count : results_to;
 
+                    results_to = ( results_to > data.meta.total_count ) ? data.meta.total_count : results_to;
 
                     scope.respondents = data.objects;
                     scope.meta = data.meta;

--- a/server/static/survey/components/p97-respondent-table/directives.js
+++ b/server/static/survey/components/p97-respondent-table/directives.js
@@ -1,0 +1,137 @@
+/*
+    
+    Displays a list of respondants in a sortable pagiantated table. 
+    
+    Usage:
+
+        <table respondant-table 
+               resource='/api/v1/completerespondant/' 
+               params='data.queryParams'
+               options='{page_size:15}'>
+
+    Inputs:
+
+        resource - the API endpoint, e.g. '/api/v1/dashrespondant', '/api/v1/dashrespondant/search'
+        params - An object whose keyword/values are added as query parmameters on the request. 
+               - complete : [BOOLEAN]
+               - ef : [STRING] A ',' list of ecofsystem features
+               - q: [STRING] A query term to search on, only used when using 
+                             the '/api/v1/dashrespondant/search' endpoint
+        options: Object containing the following options:
+               - limit : [INTEGER] Number of records to show per page 
+        
+
+*/
+
+angular.module('askApp')
+    .directive('respondentsTable', ['$http', '$location', 'surveyFactory', function(http, location, surveyFactory) {
+
+    return {
+        restrict: 'EA',
+        templateUrl : app.viewPath +'components/p97-respondent-table/templates/table.html',
+        scope: {
+                resource:'=',
+                options:'=',
+            },
+
+        link: function (scope, element, attrs) {
+            scope.respondents = null;
+            scope.orderBy = null;
+            scope.meta = null;
+            scope.http = http;
+            scope.surveySlug = surveyFactory.survey.slug;
+            scope.location = location;
+
+            // Get the search term from the URL
+            scope.searchTerm = scope.location.search().q;
+
+            // Paginated respondent table
+            scope.goToPage = function (page) {
+                /*
+                Page is a page index
+                */
+                
+                var meta = scope.meta || {}
+                    , offset = scope.options.limit * (page - 1);
+
+                var url = scope.build_url(offset);
+                console.log(url)
+
+                scope.http.get(url).success(function (data) {
+                    
+                    // make sure the to parts is not grater than the total count.
+                    var results_to = data.meta.offset + data.meta.limit;
+                    results_to = ( results_to > data.meta.total_count ) ? data.meta.total_count : results_to;
+
+
+                    scope.respondents = data.objects;
+                    scope.meta = data.meta;
+                    scope.currentPage = page;
+                    scope.results_from = scope.meta.offset + 1;
+                    scope.results_to = results_to;
+                });
+            };
+
+            scope.setOrderBy = function(field){
+                if (scope.orderBy === field){
+                    scope.orderBy = "-"+field;
+                } else if (scope.orderBy === '-'+field){
+                    scope.orderBy = null;
+                } else {
+                    scope.orderBy = field;
+                }
+            };
+
+            scope.showRespondent = function(respondent){
+                /*
+                This is the row click callback that takes the user to the respondaent detail page.
+                */
+                scope.location.path('/RespondantDetail/'+respondent.survey_slug+'/'+respondent.uuid );
+            };
+
+            scope.build_url = function(offset){
+                /*
+                Builds a URL based on pagination, user permissions, and search terms.
+                
+                Inputs:
+                    offset: [INTEGER] the 0-based page offset
+
+                /resource/?format='json'&limit=XX&offset=YY&q=SSSSS&complete=BOOL
+
+                */
+
+                // Attach pagination
+                var url = [ 
+                            scope.resource ,
+                            '?format=json&limit=',
+                            scope.options.limit,
+                            '&offset=',
+                            offset,
+                          ];
+
+                if (scope.searchTerm) {
+                    url.push('&q='+scope.searchTerm);
+                };
+                if (!scope.$parent.user.is_staff){
+                    url.push('&complete=true')
+                }
+
+                url = url.join('');
+                return url;
+
+            };
+
+
+            // Load data when the resource is defined.
+            scope.$watch('resource', function(newVal){
+                if (newVal && scope.respondents === null){
+                    scope.goToPage(1);
+                }
+            });
+
+
+
+        }
+    };
+}]);
+

--- a/server/static/survey/components/p97-respondent-table/directives.js
+++ b/server/static/survey/components/p97-respondent-table/directives.js
@@ -54,7 +54,7 @@ angular.module('askApp')
                 var meta = scope.meta || {}
                     , offset = scope.options.limit * (page - 1);
 
-                var url = scope.build_url(offset);
+                var url = scope.build_url(offset, page);
                 console.log(url)
 
                 scope.http.get(url).success(function (data) {
@@ -89,12 +89,15 @@ angular.module('askApp')
                 scope.location.path('/RespondantDetail/'+respondent.survey_slug+'/'+respondent.uuid );
             };
 
-            scope.build_url = function(offset){
+            scope.build_url = function(offset, page){
                 /*
                 Builds a URL based on pagination, user permissions, and search terms.
                 
                 Inputs:
                     offset: [INTEGER] the 0-based page offset
+                    page: [INTEGER] 1-based page index. This is only used on the search mode endpoint 
+                                    and should not be generalize.
+
 
                 /resource/?format='json'&limit=XX&offset=YY&q=SSSSS&complete=BOOL
 
@@ -116,9 +119,15 @@ angular.module('askApp')
                     url.push('&complete=true')
                 }
 
+
+                // If search mode add the page number. This is becuase of
+                // an artifact of the dashrespodant/search endpoint. 
+                if (scope.resource.search('/search') >= 0){
+                    url.push('&page='+page);    
+                }
+                
                 url = url.join('');
                 return url;
-
             };
 
 

--- a/server/static/survey/components/p97-respondent-table/directives.js
+++ b/server/static/survey/components/p97-respondent-table/directives.js
@@ -32,6 +32,7 @@ angular.module('askApp')
         scope: {
                 resource:'=',
                 options:'=',
+                params:'='
             },
 
         link: function (scope, element, attrs) {
@@ -55,7 +56,7 @@ angular.module('askApp')
                     , offset = scope.options.limit * (page - 1);
 
                 var url = scope.build_url(offset, page);
-                console.log(url)
+                console.log("Fetching results from " + url);
 
                 scope.http.get(url).success(function (data) {
                     
@@ -91,16 +92,15 @@ angular.module('askApp')
 
             scope.build_url = function(offset, page){
                 /*
-                Builds a URL based on pagination, user permissions, and search terms.
-                
-                Inputs:
-                    offset: [INTEGER] the 0-based page offset
-                    page: [INTEGER] 1-based page index. This is only used on the search mode endpoint 
-                                    and should not be generalize.
+                    Builds a URL based on pagination, user permissions, and search terms.
+                    
+                    Inputs:
+                        offset: [INTEGER] the 0-based page offset
+                        page: [INTEGER] 1-based page index. This is only used on the search mode endpoint 
+                                        and should not be generalize.
 
 
-                /resource/?format='json'&limit=XX&offset=YY&q=SSSSS&complete=BOOL
-
+                    /resource/?format='json'&limit=XX&offset=YY&q=SSSSS&complete=BOOL
                 */
 
                 // Attach pagination
@@ -112,18 +112,27 @@ angular.module('askApp')
                             offset,
                           ];
 
+
+                // Deal with search term
                 if (scope.searchTerm) {
                     url.push('&q='+scope.searchTerm);
                 };
+
+                // Deal with staff users
                 if (!scope.$parent.user.is_staff){
                     url.push('&complete=true')
                 }
-
 
                 // If search mode add the page number. This is becuase of
                 // an artifact of the dashrespodant/search endpoint. 
                 if (scope.resource.search('/search') >= 0){
                     url.push('&page='+page);    
+                }
+
+                // Add any ecosystem filters if necessary
+                if (scope.params.ef && scope.params.ef.length > 0){
+                    var txt = '&ef='+scope.params.ef.join(',');
+                    url.push(txt);
                 }
                 
                 url = url.join('');
@@ -138,6 +147,11 @@ angular.module('askApp')
                 }
             });
 
+            // Watch the params to see if ef changed
+            scope.$watch('params.ef', function(newVal){
+                scope.goToPage(1);
+
+            });
 
 
         }

--- a/server/static/survey/components/p97-respondent-table/templates/table.html
+++ b/server/static/survey/components/p97-respondent-table/templates/table.html
@@ -55,12 +55,12 @@
 
 
 <div class="pull-left">
-    Showing {{ meta.offset + 1 }}-{{ meta.offset + meta.limit }} of {{ meta.total_count+1 }}
+    Showing {{ results_from }} - {{ results_to }} of {{ meta.total_count }}
 </div>
 <div class="pull-right">
     <div pagination 
         total-items="meta.total_count" 
-        items-per-page="8" 
+        items-per-page="scope.options.limit" 
         max-size="8" 
         page="currentPage"
         previous-text="&lsaquo;" 

--- a/server/static/survey/components/p97-respondent-table/templates/table.html
+++ b/server/static/survey/components/p97-respondent-table/templates/table.html
@@ -60,7 +60,7 @@
 <div class="pull-right">
     <div pagination 
         total-items="meta.total_count" 
-        items-per-page="scope.options.limit" 
+        items-per-page="options.limit" 
         max-size="8" 
         page="currentPage"
         previous-text="&lsaquo;" 

--- a/server/static/survey/views/RespondantList.html
+++ b/server/static/survey/views/RespondantList.html
@@ -10,7 +10,7 @@
             
             <div class="row" ng-hide="busy">
                 <div class="col-md-12 col-sm-12">
-                <h3 ng-Show='searchTerm'>Matching Reports for '{{searchTerm}}'</h3>
+                <h3 ng-show='searchTerm'>Matching Reports for '{{searchTerm}}'</h3>
                 <div respondents-table respondents='respondents' meta='meta'></div>
                 </div>
             </div>

--- a/server/static/survey/views/RespondantList.html
+++ b/server/static/survey/views/RespondantList.html
@@ -10,8 +10,8 @@
             
             <div class="row" ng-hide="busy">
                 <div class="col-md-12 col-sm-12">
-                <h3>Matching Reports for '{{searchTerm}}'</h3>
-                <div respondents-table respondents='respondents' resource='resource' meta='meta'></div>
+                <h3 ng-Show='searchTerm'>Matching Reports for '{{searchTerm}}'</h3>
+                <div respondents-table respondents='respondents' meta='meta'></div>
                 </div>
             </div>
 

--- a/server/static/survey/views/ost/dash-explore.html
+++ b/server/static/survey/views/ost/dash-explore.html
@@ -32,7 +32,7 @@
         <div class="row">
             <div class="col-sm-12">
                 <h3>Matching Reports</h3>
-                <div respondents-table respondents='respondents' resource='resource' meta='meta' limit='respondents_per_page'></div>
+                <div respondents-table respondents='respondents' meta='meta' limit='respondents_per_page'></div>
             </div>
         </div>
     </div><!-- end main-content -->

--- a/server/static/survey/views/ost/dash-explore.html
+++ b/server/static/survey/views/ost/dash-explore.html
@@ -32,7 +32,11 @@
         <div class="row">
             <div class="col-sm-12">
                 <h3>Matching Reports</h3>
-                <div respondents-table respondents='respondents' meta='meta' limit='respondents_per_page'></div>
+                <div respondents-table 
+                     resource='respondentTable.resource'
+                     params='respondentTable.params' 
+                     options='respondentTable.options'
+                ></div>
             </div>
         </div>
     </div><!-- end main-content -->

--- a/server/static/survey/views/ost/dash-overview.html
+++ b/server/static/survey/views/ost/dash-overview.html
@@ -51,8 +51,8 @@
                 <div respondents-table 
                     resource='respondentTable.resource'
                     params='respondentTable.params' 
-                    options='respondentTable.options'>
-                </div>
+                    options='respondentTable.options'
+                ></div>
             </div>
         </div>
     </div><!-- main-content -->

--- a/server/static/survey/views/ost/dash-overview.html
+++ b/server/static/survey/views/ost/dash-overview.html
@@ -47,7 +47,12 @@
         <div class="row">
             <div class="col-sm-12">
                 <h3>Projects</h3>
-                <div respondents-table respondents='respondents' resource='resource' meta='meta'></div>
+                WTF{{respondentTable}}
+                <div respondents-table 
+                    resource='respondentTable.resource'
+                    params='respondentTable.params' 
+                    options='respondentTable.options'>
+                </div>
             </div>
         </div>
     </div><!-- main-content -->

--- a/server/static/survey/views/ost/dash-overview.html
+++ b/server/static/survey/views/ost/dash-overview.html
@@ -47,7 +47,6 @@
         <div class="row">
             <div class="col-sm-12">
                 <h3>Projects</h3>
-                WTF{{respondentTable}}
                 <div respondents-table 
                     resource='respondentTable.resource'
                     params='respondentTable.params' 

--- a/server/static/survey/views/ost/dash-respondent-list.html
+++ b/server/static/survey/views/ost/dash-respondent-list.html
@@ -2,10 +2,16 @@
 <div class="main dash-responses" ng-cloak>
     <div class="row" ost-header></div>
     <div class="main-content">
-        <div class="row" ng-hide="busy">
+        <div class="row">
             <div class="col-md-12 col-sm-12">
             <h3 ng-show="searchTerm">Matching Reports for '{{searchTerm}}'</h3>
-            <div respondents-table respondents='respondents' resource='resource' meta='meta' limit='respondents_per_page'></div>
+            
+            <div respondents-table 
+                 resource='respondentTable.resource'
+                 params='respondentTable.params' 
+                 options='respondentTable.options'
+            ></div>
+
             </div>
         </div>
     </div>

--- a/server/static/survey/views/ost/dash-respondent-list.html
+++ b/server/static/survey/views/ost/dash-respondent-list.html
@@ -4,7 +4,7 @@
     <div class="main-content">
         <div class="row" ng-hide="busy">
             <div class="col-md-12 col-sm-12">
-            <h3>Matching Reports for '{{searchTerm}}'</h3>
+            <h3 ng-show="searchTerm">Matching Reports for '{{searchTerm}}'</h3>
             <div respondents-table respondents='respondents' resource='resource' meta='meta' limit='respondents_per_page'></div>
             </div>
         </div>


### PR DESCRIPTION
@edrex I redid the respondent table directive and the dashrespondent API endpoint. 

I used the 'component' structure @timglaser and I have been experimenting with. You'll see it in components/p97-respondent-table/. The idea is that we can copy that whole folder into a general P97 shared repo. Then we can build p97-components.js, p97-components.css, and a p97-components-templates/ from these components.

Also I moved all the logic to load and paginate the respondent table into the directive. This include the AJAX calls. I am not sure that AJAX calls belong in a directive, but it seems to work well. What do you think?

I still need to incorporate the filter values into the params being sent to the respondent-table directive, so the table has responsive filtering. I also still need to make the entire endpoint sortable. 

Also you will probable need to run a ./manage.py rebuild_indexes on your local vagrant. 
